### PR TITLE
Board-Category ロジック作成

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,9 +8,9 @@ export const Footer: VFC = memo(() => {
     <_Footer>
       <_Inner>
         <_Links>
-          <Link to="/article">Article</Link>
+          <Link to="/article/">Article</Link>
           <span>|</span>
-          <Link to="/board">Board</Link>
+          <Link to="/board/">Board</Link>
         </_Links>
         <_Copyright>&copy; 2022 Growth Odyssey. All Rights Resarved.</_Copyright>
       </_Inner>

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -1,5 +1,6 @@
 import { VFC, memo, ReactNode } from 'react';
 import styled from 'styled-components';
+import { palette } from '../variable';
 
 type props = {
   children: ReactNode;
@@ -19,8 +20,13 @@ const _SideBar = styled.div`
   background: #fff;
   > a {
     display: block;
+    &.is-active {
+      color: ${palette.orange};
+      font-weight: bold;
+      pointer-events: none;
+    }
     &:not(:first-of-type) {
-      margin-top: 10px;
+      margin-top: 5px;
     }
   }
 `;

--- a/src/components/board/Card.tsx
+++ b/src/components/board/Card.tsx
@@ -13,7 +13,7 @@ export const BoardCard: VFC<props> = memo((props) => {
   const { threadId, threadTitle, commentsCount, updatedAt } = props.data;
   return (
     <_Card>
-      <Link to={`/board/detail/${threadId}`}>
+      <Link to={`/board/detail/${threadId}/`}>
         <p>{threadTitle}</p>
         <p>コメント数：{commentsCount}</p>
         <p>

--- a/src/components/board/SideBar.tsx
+++ b/src/components/board/SideBar.tsx
@@ -1,0 +1,25 @@
+import { VFC, memo } from 'react';
+import { Link } from 'react-router-dom';
+import { SideBar } from '../SideBar';
+
+type props = {
+  isVisible: 'top' | 'create';
+};
+
+export const BoardSideBar: VFC<props> = memo((props) => {
+  const { isVisible } = props;
+
+  return (
+    <SideBar>
+      <Link className={isVisible === 'top' ? 'is-active' : ''} to="/board/">
+        掲示板TOP
+      </Link>
+      <Link className={isVisible === 'create' ? 'is-active' : ''} to="/board/create/">
+        掲示板作成
+      </Link>
+      <Link to="#" onClick={() => alert('まだ未実装デース')}>
+        掲示板検索
+      </Link>
+    </SideBar>
+  );
+});

--- a/src/pages/board/Category.tsx
+++ b/src/pages/board/Category.tsx
@@ -1,5 +1,145 @@
 import { VFC, memo } from 'react';
+import { useParams } from 'react-router-dom';
+import { BoardCard } from '../../components/board/Card';
+import { BoardSideBar } from '../../components/board/SideBar';
+import { Heading } from '../../components/common/Heading';
+import { Contents } from '../../components/Contents';
+import { thread } from '../../types/board/thread';
+
+const threads: thread[] = [
+  {
+    threadId: '1',
+    threadTitle: 'スレッドタイトル',
+    categoryId: '1',
+    commentsCount: 100,
+    comments: [
+      {
+        commentId: '1',
+        commentTitle: 'コメント',
+        userId: '1',
+        userName: 'ニックネーム',
+        sessionId: '1111',
+        createdAt: '2022-01-01T00:00:00+09:00',
+      },
+    ],
+    createdAt: '2022-01-01T00:00:00+09:00',
+    updatedAt: '2022-01-01T00:00:00+09:00',
+  },
+  {
+    threadId: '2',
+    threadTitle: 'スレッドタイトル',
+    categoryId: '1',
+    commentsCount: 100,
+    comments: [
+      {
+        commentId: '1',
+        commentTitle: 'コメント',
+        userId: '1',
+        userName: 'ニックネーム',
+        sessionId: '1111',
+        createdAt: '2022-01-01T00:00:00+09:00',
+      },
+    ],
+    createdAt: '2022-01-01T00:00:00+09:00',
+    updatedAt: '2022-01-01T00:00:00+09:00',
+  },
+  {
+    threadId: '3',
+    threadTitle: 'スレッドタイトル',
+    categoryId: '1',
+    commentsCount: 100,
+    comments: [
+      {
+        commentId: '1',
+        commentTitle: 'コメント',
+        userId: '1',
+        userName: 'ニックネーム',
+        sessionId: '1111',
+        createdAt: '2022-01-01T00:00:00+09:00',
+      },
+    ],
+    createdAt: '2022-01-01T00:00:00+09:00',
+    updatedAt: '2022-01-01T00:00:00+09:00',
+  },
+  {
+    threadId: '4',
+    threadTitle: 'スレッドタイトル',
+    categoryId: '1',
+    commentsCount: 100,
+    comments: [
+      {
+        commentId: '1',
+        commentTitle: 'コメント',
+        userId: '1',
+        userName: 'ニックネーム',
+        sessionId: '1111',
+        createdAt: '2022-01-01T00:00:00+09:00',
+      },
+    ],
+    createdAt: '2022-01-01T00:00:00+09:00',
+    updatedAt: '2022-01-01T00:00:00+09:00',
+  },
+  {
+    threadId: '5',
+    threadTitle: 'スレッドタイトル',
+    categoryId: '1',
+    commentsCount: 100,
+    comments: [
+      {
+        commentId: '1',
+        commentTitle: 'コメント',
+        userId: '1',
+        userName: 'ニックネーム',
+        sessionId: '1111',
+        createdAt: '2022-01-01T00:00:00+09:00',
+      },
+    ],
+    createdAt: '2022-01-01T00:00:00+09:00',
+    updatedAt: '2022-01-01T00:00:00+09:00',
+  },
+];
+
+const categories = [
+  {
+    id: '1',
+    name: 'HTML',
+  },
+  {
+    id: '2',
+    name: 'CSS',
+  },
+  {
+    id: '3',
+    name: 'JavaScript',
+  },
+  {
+    id: '4',
+    name: 'PHP',
+  },
+  {
+    id: '5',
+    name: 'Ruby',
+  },
+];
 
 export const BoardCategory: VFC = memo(() => {
-  return <h1>board category</h1>;
+  const { categoryId } = useParams<{ categoryId: string }>();
+
+  const getCategoryName = (id: string) => categories.find((v) => v.id === id)!.name;
+
+  return (
+    <>
+      <BoardSideBar isVisible={'create'} />
+      <Contents>
+        <Heading size={'2'}>{getCategoryName(categoryId)}のスレッド一覧</Heading>
+        <section>
+          <ul className="list">
+            {threads.map((thread) => (
+              <BoardCard key={thread.threadId} data={thread} />
+            ))}
+          </ul>
+        </section>
+      </Contents>
+    </>
+  );
 });

--- a/src/pages/board/Top.tsx
+++ b/src/pages/board/Top.tsx
@@ -2,9 +2,9 @@ import { VFC, memo } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { BoardCard } from '../../components/board/Card';
+import { BoardSideBar } from '../../components/board/SideBar';
 import { Heading } from '../../components/common/Heading';
 import { Contents } from '../../components/Contents';
-import { SideBar } from '../../components/SideBar';
 import { thread } from '../../types/board/thread';
 
 const threads: thread[] = [
@@ -126,13 +126,7 @@ const categories = [
 export const BoardTop: VFC = memo(() => {
   return (
     <>
-      <SideBar>
-        <Link to="create">掲示板作成</Link>
-        <Link to="#" style={{ pointerEvents: 'none' }}>
-          掲示板検索
-        </Link>
-      </SideBar>
-
+      <BoardSideBar isVisible={'top'} />
       <Contents>
         <Heading size={'2'}>掲示板TOP</Heading>
         <section>
@@ -147,7 +141,7 @@ export const BoardTop: VFC = memo(() => {
           <Heading size={'4'}>カテゴリー一覧</Heading>
           <_CategoryList>
             {categories.map((category) => (
-              <Link to={`/board/category/${category.id}`} key={category.id}>
+              <Link to={`/board/category/${category.id}/`} key={category.id}>
                 {category.name}
               </Link>
             ))}

--- a/src/router/PageRoutes.tsx
+++ b/src/router/PageRoutes.tsx
@@ -47,8 +47,9 @@ export const pageRoutes = [
     children: <BoardTop />,
   },
   {
-    path: '/board/category',
+    path: '/board/category/:categoryId',
     exact: false,
+    sideBar: true,
     children: <BoardCategory />,
   },
   {


### PR DESCRIPTION
## issue
・board/category/のロジック部分の作成。

## 対応内容
・カテゴリーIDをパスパラメータで受け取れるようにし、IDに応じたコンテンツを表示するようにした。
・Boardページで使うサイドバーをコンポーネントにして共通化。