### PR TITLE
記事詳細画面の作成

### DIFF
--- a/src/components/article/MarkDownEditor.tsx
+++ b/src/components/article/MarkDownEditor.tsx
@@ -45,16 +45,16 @@ const _Markdown = styled.div`
     margin-top: 1em;
   }
   h1 {
-    font-size: 34px;
+    font-size: 28px;
   }
   h2 {
-    font-size: 30px;
+    font-size: 24px;
   }
   h3 {
-    font-size: 26px;
+    font-size: 22px;
   }
   h4 {
-    font-size: 22px;
+    font-size: 20px;
   }
   h5 {
     font-size: 18px;

--- a/src/components/article/MarkDownEditor.tsx
+++ b/src/components/article/MarkDownEditor.tsx
@@ -9,7 +9,7 @@ import DOMPurify from 'dompurify';
 type props = {
   isEdit: boolean;
   value: string;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
 };
 
 export const MarkDownEditor: VFC<props> = memo((props) => {
@@ -28,13 +28,22 @@ export const MarkDownEditor: VFC<props> = memo((props) => {
       {isEdit ? (
         <SimpleMde value={value} onChange={onChange} />
       ) : (
-        <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(value)) }} />
+        <span
+          className="content"
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(value)) }}
+        />
       )}
     </_Markdown>
   );
 });
 
 const _Markdown = styled.div`
+  > .content > *:first-child {
+    margin-top: 0;
+  }
+  p + p {
+    margin-top: 1em;
+  }
   h1 {
     font-size: 34px;
   }
@@ -55,6 +64,7 @@ const _Markdown = styled.div`
   h3,
   h4,
   h5 {
+    margin: 1em 0 1.2em 0;
     font-weight: bold;
   }
   h1,
@@ -67,17 +77,13 @@ const _Markdown = styled.div`
   }
   ul {
     > li {
-      &::before {
-        content: '⚫︎';
-      }
+      list-style-type: disc;
       > ul {
         > li {
-          &::before {
-            content: '⚪︎';
-          }
+          list-style-type: circle;
           > ul {
-            > li::before {
-              content: '◼️';
+            > li {
+              list-style-type: square;
             }
           }
         }
@@ -90,23 +96,23 @@ const _Markdown = styled.div`
       counter-increment: num;
       &::before {
         content: counter(num) '.';
+        margin-right: 10px;
         font-size: 16px;
       }
     }
   }
+  ul,
+  ol {
+    margin: 1.5em 0;
+    ul,
+    ol {
+      margin: 0;
+    }
+  }
   li {
-    position: relative;
-    min-height: 24px;
-    padding-left: 1em;
+    list-style-position: inside;
     > ul {
       padding-left: 20px;
-    }
-    &::before {
-      position: absolute;
-      top: 5px;
-      left: 0;
-      margin-right: 4px;
-      font-size: 10px;
     }
   }
   blockquote {

--- a/src/hooks/useArticle.tsx
+++ b/src/hooks/useArticle.tsx
@@ -1,14 +1,24 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import axios from 'axios';
 import { apiPath } from '../variable';
-import { articles } from '../mock/articleData';
+import { articles, m_article } from '../mock/articleData';
 import { useHistory } from 'react-router-dom';
 import { useToast } from '../providers/ToastProvider';
+import { articleDetailType } from '../types/article/articleDetailType';
 
 // prettier-ignore
 export const useArticle = () => {
   const history = useHistory();
   const { setToast } = useToast();
+  const [article, setArticle] = useState<articleDetailType>({
+    articleId: '',
+    articleTitle: '',
+    contents: '',
+    avatarId: '',
+    userName: '',
+    createdAt: '',
+    updatedAt: '',
+  });
   /**
    * 記事一覧取得API
    */
@@ -40,9 +50,14 @@ export const useArticle = () => {
 
   /**
    * 記事取得API
+   * @param  {string} articleId
+   * @return {articleDetailType}
    */
-  const getArticle = useCallback(() => {
-    //
+  const getArticle = useCallback((articleId: string) => {
+    axios
+      .get(`${apiPath}/articles/${articleId}`)
+      .then((res) => setArticle(res.data))
+      .catch(() => setArticle(m_article));
   }, []);
 
   /**
@@ -59,5 +74,5 @@ export const useArticle = () => {
     //
   }, []);
 
-  return { getArticleList, createArticle, getArticle, updateArticle, removeArticle };
+  return { article, getArticleList, createArticle, getArticle, updateArticle, removeArticle };
 };

--- a/src/mock/articleData.ts
+++ b/src/mock/articleData.ts
@@ -18,3 +18,14 @@ export const articles: articleType[] = [
     updatedAt: '2022-01-01T00:00:00+09:00',
   },
 ];
+
+export const m_article = {
+  articleId: '1',
+  articleTitle: '記事名1',
+  contents:
+    '# h1見出し\n## h2見出し\n### h3見出し\n#### h4見出し\n##### h5見出し\n\n本文テキスト\n**太字テキスト**\n*斜体テキスト*\n\n> 引用文\n\n* Generic List\n  * 2階層目\n    * 3階層目\n\n1. Numbered List\n2. 項目その２\n\n[Google.comのリンク](https://www.google.com/?hl=ja)\n\nコードブロック\n```js\nconst sayHello = (name) => {\n    console.log(`Hello ${name}!!`);\n}\nsayHello("Mike"); // "Hello Mike!!"\n```\n',
+  avatarId: '001',
+  userName: 'ニックネーム1',
+  createdAt: '2022-01-01T00:00:00+09:00',
+  updatedAt: '2022-01-01T00:00:00+09:00',
+};

--- a/src/pages/article/Detail.tsx
+++ b/src/pages/article/Detail.tsx
@@ -2,7 +2,7 @@ import { VFC, memo, useEffect } from 'react';
 import { useParams } from 'react-router';
 import styled from 'styled-components';
 import { MarkDownEditor } from '../../components/article/MarkDownEditor';
-import { BoardSideBar } from '../../components/board/SideBar';
+import { ArticleSideBar } from '../../components/article/SideBar';
 import { AvatarIcon } from '../../components/common/AvatarIcon';
 import { DateText } from '../../components/common/DateText';
 import { Heading } from '../../components/common/Heading';
@@ -20,12 +20,12 @@ export const ArticleDetail: VFC = memo(() => {
 
   return (
     <>
-      <BoardSideBar />
+      <ArticleSideBar />
       <Contents>
         <Heading size={'2'}>{article.articleTitle}</Heading>
         <_Author>
           <p className="user">
-            <AvatarIcon avatorId="001" alt="" width="20px" />
+            <AvatarIcon avatorId="149" alt="" width="36px" />
             <span className="name">{article.userName}</span>
           </p>
           <span className="date">

--- a/src/pages/article/Detail.tsx
+++ b/src/pages/article/Detail.tsx
@@ -25,7 +25,7 @@ export const ArticleDetail: VFC = memo(() => {
         <Heading size={'2'}>{article.articleTitle}</Heading>
         <_Author>
           <p className="user">
-            <AvatarIcon avatorId="149" alt="" width="36px" />
+            <AvatarIcon avatorId={article.avatarId} alt="" width="36px" />
             <span className="name">{article.userName}</span>
           </p>
           <span className="date">

--- a/src/pages/article/Detail.tsx
+++ b/src/pages/article/Detail.tsx
@@ -22,7 +22,7 @@ export const ArticleDetail: VFC = memo(() => {
     <>
       <ArticleSideBar />
       <Contents>
-        <Heading size={'2'}>{article.articleTitle}</Heading>
+        <Heading size={'1'}>{article.articleTitle}</Heading>
         <_Author>
           <p className="user">
             <AvatarIcon avatorId={article.avatarId} alt="" width="36px" />
@@ -58,6 +58,7 @@ const _Author = styled.div`
   }
   > .date {
     color: ${palette.gray[1]};
+    font-size: 14px;
     > .label {
       margin: 0 8px 0 16px;
     }

--- a/src/pages/article/Detail.tsx
+++ b/src/pages/article/Detail.tsx
@@ -1,5 +1,70 @@
-import { VFC, memo } from 'react';
+import { VFC, memo, useEffect } from 'react';
+import { useParams } from 'react-router';
+import styled from 'styled-components';
+import { MarkDownEditor } from '../../components/article/MarkDownEditor';
+import { BoardSideBar } from '../../components/board/SideBar';
+import { AvatarIcon } from '../../components/common/AvatarIcon';
+import { DateText } from '../../components/common/DateText';
+import { Heading } from '../../components/common/Heading';
+import { Contents } from '../../components/Contents';
+import { useArticle } from '../../hooks/useArticle';
+import { palette } from '../../variable';
 
 export const ArticleDetail: VFC = memo(() => {
-  return <h1>article detail</h1>;
+  const { id } = useParams<{ id: string }>();
+  const { article, getArticle } = useArticle();
+
+  useEffect(() => {
+    getArticle(id);
+  }, [id]);
+
+  return (
+    <>
+      <BoardSideBar />
+      <Contents>
+        <Heading size={'2'}>{article.articleTitle}</Heading>
+        <_Author>
+          <p className="user">
+            <AvatarIcon avatorId="001" alt="" width="20px" />
+            <span className="name">{article.userName}</span>
+          </p>
+          <span className="date">
+            <span className="label">投稿日</span>
+            <DateText>{article.createdAt}</DateText>
+            <span className="label">更新日</span>
+            <DateText>{article.updatedAt}</DateText>
+          </span>
+        </_Author>
+        <_Content>
+          <MarkDownEditor isEdit={false} value={article.contents} />
+        </_Content>
+      </Contents>
+    </>
+  );
 });
+
+const _Author = styled.div`
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+  margin-bottom: 0.5em;
+  > .user {
+    display: flex;
+    align-items: center;
+    font-weight: bold;
+    > .name {
+      margin-left: 8px;
+    }
+  }
+  > .date {
+    color: ${palette.gray[1]};
+    > .label {
+      margin: 0 8px 0 16px;
+    }
+  }
+`;
+
+const _Content = styled.div`
+  padding: 20px;
+  background: #fff;
+`;

--- a/src/router/PageRoutes.tsx
+++ b/src/router/PageRoutes.tsx
@@ -40,6 +40,7 @@ export const pageRoutes = [
   {
     path: '/article/detail',
     exact: false,
+    sideBar: true,
     children: <ArticleDetail />,
   },
   {

--- a/src/types/article/articleDetailType.ts
+++ b/src/types/article/articleDetailType.ts
@@ -1,0 +1,9 @@
+export type articleDetailType = {
+  articleId: string;
+  articleTitle: string;
+  contents: string;
+  avatarId: string;
+  userName: string;
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## issue
- article/detail/{articleId}のロジック部分の作成。
https://github.com/orgs/GrowthOdyssey/projects/1#card-76129876

## 変更内容
- マークダウンのHTML表示のstyleを修正
- 記事詳細画面に適用
- useArticlesのgetArticleの関数を作成、詳細画面に適用
  - API完成まではcatchの方にモックデータのロジックを一旦記述