### PR TITLE
自分の記事を編集する

### DIFF
--- a/src/components/article/Card.tsx
+++ b/src/components/article/Card.tsx
@@ -1,6 +1,7 @@
 import { memo, VFC } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useLoginUser } from '../../providers/LoginUserProvider';
 import { articleType } from '../../types/article/articleType';
 import { palette } from '../../variable';
 import { AvatarIcon } from '../common/AvatarIcon';
@@ -11,7 +12,8 @@ type props = {
 };
 
 export const ArticleCard: VFC<props> = memo((props) => {
-  const { articleId, articleTitle, userName, createdAt } = props.data;
+  const { articleId, articleTitle, userId, userName, createdAt } = props.data;
+  const { loginUser } = useLoginUser();
   return (
     <_Card>
       <Link to={`/article/detail/${articleId}`}>
@@ -22,17 +24,38 @@ export const ArticleCard: VFC<props> = memo((props) => {
         </div>
         <_Title>{articleTitle}</_Title>
       </Link>
+      {userId === loginUser.userId && (
+        <div className="buttons">
+          <Link to={`/article/edit/${articleId}`}>編集</Link>
+        </div>
+      )}
     </_Card>
   );
 });
 
 const _Card = styled.li`
+  position: relative;
+  padding: 10px 20px;
   background: #fff;
   border: 1px solid ${palette.border};
   border-radius: 4px;
-  > a {
-    display: block;
-    padding: 10px 20px;
+  > .buttons {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    display: flex;
+    justify-content: flex-end;
+    > a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px;
+      height: 30px;
+      margin-left: 4px;
+      border: 1px solid ${palette.border};
+      border-radius: 50%;
+      font-size: 12px;
+    }
   }
 `;
 

--- a/src/components/article/SideBar.tsx
+++ b/src/components/article/SideBar.tsx
@@ -23,7 +23,7 @@ export const ArticleSideBar: VFC<props> = memo((props) => {
         記事検索
       </Link>
       {loginUser.userId && (
-        <Link className={isVisible === 'mypage' ? 'is-active' : ''} to={`/article?userId=${loginUser.userId}`}>
+        <Link className={isVisible === 'mypage' ? 'is-active' : ''} to="/article/mypage">
           投稿した記事
         </Link>
       )}

--- a/src/components/article/SideBar.tsx
+++ b/src/components/article/SideBar.tsx
@@ -1,13 +1,15 @@
 import { memo, VFC } from 'react';
 import { Link } from 'react-router-dom';
+import { useLoginUser } from '../../providers/LoginUserProvider';
 import { SideBar } from '../SideBar';
 
 type props = {
-  isVisible?: 'top' | 'create';
+  isVisible?: 'top' | 'create' | 'mypage';
 };
 
 export const ArticleSideBar: VFC<props> = memo((props) => {
   const { isVisible } = props;
+  const { loginUser } = useLoginUser();
 
   return (
     <SideBar>
@@ -20,6 +22,11 @@ export const ArticleSideBar: VFC<props> = memo((props) => {
       <Link to="#" onClick={() => alert('まだ未実装デース')}>
         記事検索
       </Link>
+      {loginUser.userId && (
+        <Link className={isVisible === 'mypage' ? 'is-active' : ''} to={`/article?userId=${loginUser.userId}`}>
+          投稿した記事
+        </Link>
+      )}
     </SideBar>
   );
 });

--- a/src/hooks/useRedirect.tsx
+++ b/src/hooks/useRedirect.tsx
@@ -7,5 +7,7 @@ export const useRedirect = () => {
 
   const goBack = () => history.goBack();
 
-  return { toTop, goBack };
+  const toLogin = () => history.push('/login');
+
+  return { toTop, goBack, toLogin };
 };

--- a/src/mock/articleData.ts
+++ b/src/mock/articleData.ts
@@ -4,7 +4,7 @@ export const m_articles: articleType[] = [
   {
     articleId: '1',
     articleTitle: '記事名1',
-    userId: 'userId1',
+    userId: '1',
     userName: 'ニックネーム1',
     createdAt: '2022-01-01T00:00:00+09:00',
     updatedAt: '2022-01-01T00:00:00+09:00',
@@ -12,7 +12,7 @@ export const m_articles: articleType[] = [
   {
     articleId: '2',
     articleTitle: '記事名2',
-    userId: 'userId2',
+    userId: '2',
     userName: 'ニックネーム2',
     createdAt: '2022-01-01T00:00:00+09:00',
     updatedAt: '2022-01-01T00:00:00+09:00',

--- a/src/pages/article/List.tsx
+++ b/src/pages/article/List.tsx
@@ -1,6 +1,6 @@
-import { memo, VFC } from "react";
-import { ArticleCard } from "../../components/article/Card";
-import { articleType } from "../../types/article/articleType";
+import { memo, VFC } from 'react';
+import { ArticleCard } from '../../components/article/Card';
+import { articleType } from '../../types/article/articleType';
 
 type props = {
   articleList: articleType[];

--- a/src/pages/article/List.tsx
+++ b/src/pages/article/List.tsx
@@ -1,0 +1,19 @@
+import { memo, VFC } from "react";
+import { ArticleCard } from "../../components/article/Card";
+import { articleType } from "../../types/article/articleType";
+
+type props = {
+  articleList: articleType[];
+};
+
+export const ArticleList: VFC<props> = memo((props) => {
+  const { articleList } = props;
+
+  return (
+    <ul className="list">
+      {articleList.map((article) => (
+        <ArticleCard key={article.articleId} data={article} />
+      ))}
+    </ul>
+  );
+});

--- a/src/pages/article/MyPage.tsx
+++ b/src/pages/article/MyPage.tsx
@@ -1,0 +1,43 @@
+import { VFC, memo, useEffect } from 'react';
+import { ArticleCard } from '../../components/article/Card';
+import { ArticleSideBar } from '../../components/article/SideBar';
+import { Heading } from '../../components/common/Heading';
+import { Loading } from '../../components/common/Loading';
+import { Contents } from '../../components/Contents';
+import { useArticle } from '../../hooks/useArticle';
+import { useRedirect } from '../../hooks/useRedirect';
+import { useLoginUser } from '../../providers/LoginUserProvider';
+
+export const ArticleMyPage: VFC = memo(() => {
+  const { articleList, loading, getArticleList } = useArticle();
+  const { loginUser } = useLoginUser();
+  const { toLogin } = useRedirect();
+
+  useEffect(() => {
+    if (!loginUser.userId) {
+      toLogin();
+    }
+    getArticleList('1', '20', loginUser.userId);
+  }, [loginUser]);
+
+  return (
+    <>
+      <ArticleSideBar isVisible={loginUser.userId ? 'mypage' : 'top'} />
+      {loading ? (
+        <Loading />
+      ) : (
+        <Contents>
+          <Heading size={'2'}>{loginUser.userName + 'の投稿した記事一覧'}</Heading>
+          <section>
+            <Heading size={'4'}>最新の記事一覧</Heading>
+            <ul className="list">
+              {articleList.map((article) => (
+                <ArticleCard key={article.articleId} data={article} />
+              ))}
+            </ul>
+          </section>
+        </Contents>
+      )}
+    </>
+  );
+});

--- a/src/pages/article/MyPage.tsx
+++ b/src/pages/article/MyPage.tsx
@@ -1,5 +1,4 @@
 import { VFC, memo, useEffect } from 'react';
-import { ArticleCard } from '../../components/article/Card';
 import { ArticleSideBar } from '../../components/article/SideBar';
 import { Heading } from '../../components/common/Heading';
 import { Loading } from '../../components/common/Loading';
@@ -7,6 +6,7 @@ import { Contents } from '../../components/Contents';
 import { useArticle } from '../../hooks/useArticle';
 import { useRedirect } from '../../hooks/useRedirect';
 import { useLoginUser } from '../../providers/LoginUserProvider';
+import { ArticleList } from './List';
 
 export const ArticleMyPage: VFC = memo(() => {
   const { articleList, loading, getArticleList } = useArticle();
@@ -22,7 +22,7 @@ export const ArticleMyPage: VFC = memo(() => {
 
   return (
     <>
-      <ArticleSideBar isVisible={loginUser.userId ? 'mypage' : 'top'} />
+      <ArticleSideBar isVisible={'mypage'} />
       {loading ? (
         <Loading />
       ) : (
@@ -30,11 +30,7 @@ export const ArticleMyPage: VFC = memo(() => {
           <Heading size={'2'}>{loginUser.userName + 'の投稿した記事一覧'}</Heading>
           <section>
             <Heading size={'4'}>最新の記事一覧</Heading>
-            <ul className="list">
-              {articleList.map((article) => (
-                <ArticleCard key={article.articleId} data={article} />
-              ))}
-            </ul>
+            <ArticleList articleList={articleList} />
           </section>
         </Contents>
       )}

--- a/src/pages/article/Top.tsx
+++ b/src/pages/article/Top.tsx
@@ -1,28 +1,34 @@
 import { VFC, memo, useEffect } from 'react';
+import { useLocation } from 'react-router';
 import { ArticleCard } from '../../components/article/Card';
 import { ArticleSideBar } from '../../components/article/SideBar';
 import { Heading } from '../../components/common/Heading';
 import { Loading } from '../../components/common/Loading';
 import { Contents } from '../../components/Contents';
 import { useArticle } from '../../hooks/useArticle';
+import { useLoginUser } from '../../providers/LoginUserProvider';
 
 export const ArticleTop: VFC = memo(() => {
   const { articleList, loading, getArticleList } = useArticle();
+  const { loginUser } = useLoginUser();
+  const search = useLocation().search;
+  const query = new URLSearchParams(search);
+  const userId = query.get('userId') || '';
 
   useEffect(() => {
-    getArticleList('1', '5');
-  }, []);
+    getArticleList('1', '5', userId);
+  }, [userId]);
 
   return (
     <>
-      <ArticleSideBar isVisible={'top'} />
+      <ArticleSideBar isVisible={userId === loginUser.userId ? 'mypage' : 'top'} />
       {loading ? (
         <Loading />
       ) : (
         <Contents>
           <Heading size={'2'}>記事TOP</Heading>
           <section>
-            <Heading size={'4'}>最新の記事一覧</Heading>
+            <Heading size={'4'}>{userId === loginUser.userId && loginUser.userName + 'の'}最新の記事一覧</Heading>
             <ul className="list">
               {articleList.map((article) => (
                 <ArticleCard key={article.articleId} data={article} />

--- a/src/pages/article/Top.tsx
+++ b/src/pages/article/Top.tsx
@@ -1,39 +1,29 @@
 import { VFC, memo, useEffect } from 'react';
-import { useLocation } from 'react-router';
-import { ArticleCard } from '../../components/article/Card';
 import { ArticleSideBar } from '../../components/article/SideBar';
 import { Heading } from '../../components/common/Heading';
 import { Loading } from '../../components/common/Loading';
 import { Contents } from '../../components/Contents';
 import { useArticle } from '../../hooks/useArticle';
-import { useLoginUser } from '../../providers/LoginUserProvider';
+import { ArticleList } from './List';
 
 export const ArticleTop: VFC = memo(() => {
   const { articleList, loading, getArticleList } = useArticle();
-  const { loginUser } = useLoginUser();
-  const search = useLocation().search;
-  const query = new URLSearchParams(search);
-  const userId = query.get('userId') || '';
 
   useEffect(() => {
-    getArticleList('1', '5', userId);
-  }, [userId]);
+    getArticleList('1', '5');
+  }, [getArticleList]);
 
   return (
     <>
-      <ArticleSideBar isVisible={userId === loginUser.userId ? 'mypage' : 'top'} />
+      <ArticleSideBar isVisible={'top'} />
       {loading ? (
         <Loading />
       ) : (
         <Contents>
           <Heading size={'2'}>記事TOP</Heading>
           <section>
-            <Heading size={'4'}>{userId === loginUser.userId && loginUser.userName + 'の'}最新の記事一覧</Heading>
-            <ul className="list">
-              {articleList.map((article) => (
-                <ArticleCard key={article.articleId} data={article} />
-              ))}
-            </ul>
+            <Heading size={'4'}>最新の記事一覧</Heading>
+            <ArticleList articleList={articleList} />
           </section>
         </Contents>
       )}

--- a/src/router/PageRoutes.tsx
+++ b/src/router/PageRoutes.tsx
@@ -1,6 +1,7 @@
 import { ArticleCreate } from '../pages/article/Create';
 import { ArticleDetail } from '../pages/article/Detail';
 import { ArticleEdit } from '../pages/article/Edit';
+import { ArticleMyPage } from '../pages/article/MyPage';
 import { ArticleTop } from '../pages/article/Top';
 import { BoardCategory } from '../pages/board/Category';
 import { BoardCreate } from '../pages/board/Create';
@@ -49,6 +50,12 @@ export const pageRoutes = [
     exact: false,
     sideBar: true,
     children: <ArticleEdit />,
+  },
+  {
+    path: '/article/mypage',
+    exact: false,
+    sideBar: true,
+    children: <ArticleMyPage />,
   },
   {
     path: '/board/page=:page',


### PR DESCRIPTION
### 変更内容
- 自分の投稿した記事一覧をサイドバーに追加
- 記事一覧ようのコンポーネントを追加
- 自分の投稿した記事表示用コンポーネント追加
- 一覧画面の記事カードに編集ボタンを追加
- デザインは仮です
- mockデータのuserIdを自分のidにするかuserIdが1のユーザーを作ると確認できます